### PR TITLE
Add PaaS manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: ova-alpha
+  command: npm start
+  memory: 256M
+  buildpacks:
+  - nodejs_buildpack
+


### PR DESCRIPTION
This is the manifest file that specifies the buildpack and container spec for CloudFoundry (GOV.UK PaaS)